### PR TITLE
Diff file types

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -82,7 +82,9 @@ function readJson_ (file, cb) {
                                 }
                                 if (er) return cb(er);
                                 if (!/\.json$/.test(file)) {
-                                                parseIndex(d)
+                                                d = parseIndex(d)
+                                                if (!d) return cb(new Error('Error parsing ' + file))
+                                                extras(file, d, cb)
                                                 return
                                 }
                                 try {


### PR DESCRIPTION
This allows you to pass single files directly to read-package-json - when you already know that a package.json is not present. It also is generic enough to accept passing something like an `index.css`, etc… What do you think?
