### PR TITLE
fix the installation of man pages

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -254,7 +254,7 @@ function mans (file, data, cb) {
 function mans_ (file, data, mans, cb) {
                 var m = data.directories && data.directories.man
                 data.man = mans.map(function (mf) {
-                                return path.resolve(m, mf)
+                                return path.resolve(path.dirname(file), m, mf)
                 })
                 return cb(null, data)
 }


### PR DESCRIPTION
the 'man' portion of the 'directories' key is getting improperly
prefixed.  this patch fixes the problem.

because of this `npm install` does not properly install man
pages, either for itself or for any other packages.
