### PR TITLE
Check for error before adding Git head sha.

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -329,8 +329,11 @@ function githead_ (file, data, dir, head, cb) {
                 var headFile = head.replace(/^ref: /, '').trim()
                 headFile = path.resolve(dir, '.git', headFile)
                 fs.readFile(headFile, 'utf8', function (er, head) {
-                                head = head.replace(/^ref: /, '').trim()
-                                data.gitHead = head
+                                if (!er) {
+                                                head = head.replace(
+                                                        /^ref: /, '').trim()
+                                                data.gitHead = head
+                                }
                                 return cb(null, data)
                 })
 }


### PR DESCRIPTION
If a new Git repo has been initialised but not yet committed to, there's no file containing the latest commit hash. Check that we actually got a hash before trying to add it to the data. This fixes isaacs/npm#3002.
