### PR TITLE
Add error handling

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -329,6 +329,7 @@ function githead_ (file, data, dir, head, cb) {
                 var headFile = head.replace(/^ref: /, '').trim()
                 headFile = path.resolve(dir, '.git', headFile)
                 fs.readFile(headFile, 'utf8', function (er, head) {
+                                if (er) return cb(er);
                                 head = head.replace(/^ref: /, '').trim()
                                 data.gitHead = head
                                 return cb(null, data)


### PR DESCRIPTION
I triggered this lack of error handling when I specified a not-yet-existent git repo in my package.json.
