### PR TITLE
npm stops working if theres one package.json with a invalid dependency s...

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -536,12 +536,16 @@ function depObjectify (file, data, deps) {
                 if (!Array.isArray(deps)) return deps
                 var o = {}
                 deps.forEach(function (d) {
+                                if (typeof d === "string") {
+                                                
                                 d = d.trim().split(/(:?[@\s><=])/)
                                 var dn = d.shift()
                                 var dv = d.join("")
                                 dv = dv.trim()
                                 dv = dv.replace(/^@/, "")
                                 o[dn] = dv
+                                
+                                }
                 })
                 return o
 }


### PR DESCRIPTION
...yntax

I had a package where the dependencies where setup in a wrong way but still valid json like:
"dependencies": [ {"underscore": ">=1.1.7"} ]
which will result in npm not beeing able to install any further packages. I'm not proposing supporting a invalid dependency syntax for package.json.
Its just to make it more failsafe.
