### PR TITLE
Name can't start with underscore

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -560,6 +560,7 @@ function validName (file, data) {
                 }
                 data.name = data.name.trim()
                 if (data.name.charAt(0) === "." ||
+                    data.name.charAt(0) === "_" ||
                     data.name.match(/[\/@\s\+%:]/) ||
                     data.name !== encodeURIComponent(data.name) ||
                     data.name.toLowerCase() === "node_modules" ||


### PR DESCRIPTION
According to https://npmjs.org/doc/json.html

```
The name ends up being part of a URL, an argument on the command line, 
and a folder name. Any name with non-url-safe characters will be rejected. 
Also, it can't start with a dot or an underscore.
```
