### PR TITLE
Search instead of direct compare when checking install script

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -143,7 +143,9 @@ function extras (file, data, cb) {
 function gypfile (file, data, cb) {
                 var dir = path.dirname(file)
                 var s = data.scripts || {}
-                if (s.install === "node-gyp rebuild" && !s.preinstall)
+                if (typeof s.install === "string" &&
+                    ~s.install.indexOf("node-gyp rebuild") &&
+                    !s.preinstall)
                                 data.gypfile = true
                 if (s.install || s.preinstall)
                                 return cb(null, data);


### PR DESCRIPTION
Some modules are using variations on "node-gyp rebuild" in their install scripts (e.g. [ws](https://github.com/einaros/ws/blob/76a1ae3dde7c190f46f54a85c0fcf303de3c4351/package.json#L15) as of this writing), so it would be nice to instead do a substring search instead of an exact comparison. Making this change will prevent the need to manually set 'gypfile' to true for such packages.
