### PR TITLE
Fixed syntax error in readJson example by adding parenthesis and semi-co...

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ readJson('/path/to/package.json', console.error, false, function (er, data) {
   }
 
   console.error('the package data is', data)
-}
+});
 ```
 
 ## readJson(file, [logFn = noop], [strict = false], cb)


### PR DESCRIPTION
readJson did not work as is due to syntax error (missing parenthesis and semi-colon). Included the appropriate syntax so others can just copy and paste code and it works
