### PR TITLE
normalize-package-data@0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "glob": "~3.2.1",
     "lru-cache": "2",
-    "normalize-package-data": "~0.2"
+    "normalize-package-data": "~0.2.5"
   },
   "devDependencies": {
     "tap": "~0.2.5"


### PR DESCRIPTION
This bumps normalize-package-data to 0.2.5 so we can use the new feature for homepage guessing (https://github.com/meryn/normalize-package-data/issues/15) in npm soon 

0.2.5 also warns for usage of node-core module names

https://github.com/meryn/normalize-package-data/pull/36
