### PR TITLE
Run normalize-package-data before the extra-set of custom functions

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -84,7 +84,24 @@ function parseJson (file, er, d, log, strict, cb) {
                                 d = parseIndex(d)
                                 if (!d) return cb(parseError(er, file));
                 }
-                extras(file, d, log, strict, cb)
+                normalize(file, d, log, strict, cb)
+}
+
+function normalize (file, data, log, strict, cb) {
+                var pId = makePackageId(data)
+                function warn(msg) {
+                                if (typoWarned[pId]) return;
+                                if (log) log("package.json", pId, msg);
+                }
+                try {
+                                normalizeData(data, warn, strict)
+                }
+                catch (error) {
+                                return cb(error)
+                }
+                typoWarned[pId] = true
+
+                extras(file, data, log, strict, pId, cb)
 }
 
 
@@ -103,7 +120,7 @@ function indexjs (file, er, log, strict, cb) {
 
 
 readJson.extras = extras
-function extras (file, data, log_, strict_, cb_) {
+function extras (file, data, log_, strict_, pId, cb_) {
                 var log, strict, cb
                 for (var i = 2; i < arguments.length - 1; i++) {
                                 if (typeof arguments[i] === 'boolean')
@@ -122,7 +139,7 @@ function extras (file, data, log_, strict_, cb_) {
                                 if (errState) return;
                                 if (er) return cb(errState = er);
                                 if (--n > 0) return;
-                                final(file, data, log, strict, cb);
+                                final(file, data, log, strict, pId, cb);
                 }
 }
 
@@ -314,19 +331,7 @@ function githead_ (file, data, dir, head, cb) {
                 })
 }
 
-function final (file, data, log, strict, cb) {
-                var pId = makePackageId(data)
-                function warn(msg) {
-                                if (typoWarned[pId]) return;
-                                if (log) log("package.json", pId, msg);
-                }
-                try {
-                                normalizeData(data, warn, strict)
-                }
-                catch (error) {
-                                return cb(error)
-                }
-                typoWarned[pId] = true
+function final (file, data, log, strict, pId, cb) {
                 readJson.cache.set(file, data)
                 cb(null, data)
 }

--- a/test/extras-scripts-error.js
+++ b/test/extras-scripts-error.js
@@ -1,0 +1,15 @@
+// vim: set softtabstop=16 shiftwidth=16:
+var tap = require("tap")
+var readJson = require("../")
+var path = require("path")
+var fs = require("fs")
+
+console.error("extras-scripts-error test")
+tap.test("extras-scripts-error test", function (t) {
+                var p = path.resolve(__dirname, "fixtures/extras-scripts-error.json")
+                readJson(p, function (er, data) {
+                                if (er) throw er;
+                                t.deepEqual(data.scripts, {})
+                                t.end()
+                })
+})

--- a/test/fixtures/extras-scripts-error.json
+++ b/test/fixtures/extras-scripts-error.json
@@ -1,0 +1,11 @@
+{
+    "name": "this",
+    "description": "file",
+    "author": "has <filename>",
+    "version" : "0.0.1",
+    "scripts": {
+        "blanket": {
+            "pattern": "."
+        }
+    }
+}


### PR DESCRIPTION
normalize-package-data takes care of warning and normalizing the
malformed scripts properties, but it has to be run before the
custom functions.

fixes #28
