### PR TITLE
normalize-package-data@0.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "glob": "~3.2.1",
     "lru-cache": "2",
-    "normalize-package-data": "~0.2.7"
+    "normalize-package-data": "~0.2.9"
   },
   "devDependencies": {
     "tap": "~0.2.5"


### PR DESCRIPTION
v0.2.9 fixes a bad bug in shorthand repo urls
