### PR TITLE
Fix for inconsistent README file data, will close npm/read-package-json#31

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -230,7 +230,7 @@ function readmeDescription (file, data) {
 function readme (file, data, cb) {
                 if (data.readme) return cb(null, data);
                 var dir = path.dirname(file)
-                var globOpts = { cwd: dir, nocase: true, mark: true }
+                var globOpts = { cwd: dir, nocase: true, mark: true, sync: true }
                 glob("README?(.*)", globOpts, function (er, files) {
                                 if (er) return cb(er);
                                 // don't accept directories.


### PR DESCRIPTION
Not sure if this is the direction that you want to go, but multiple users have stated that simply making the README glob synchronous solves the issue where it isn't consistently loaded.

(Fix for issue #31)
