### PR TITLE
Prefer README.md and README to other README.*

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -238,9 +238,20 @@ function readme (file, data, cb) {
                                                 return !file.match(/\/$/)
                                 })
                                 if (!files.length) return cb();
-                                var rm = path.resolve(dir, files[0])
+                                var fn = readme_prefer(files)
+                                var rm = path.resolve(dir, fn)
                                 readme_(file, data, rm, cb)
                 })
+}
+function readme_prefer(files) {
+                var fallback = 0;
+                files.forEach(function (file, i) {
+                                if (file.match(/\.md$/i)) return file
+                                else if (file.match(/README$/)) fallback = i
+                })
+                // prefer README.md, followed by README; otherwise, return
+                // the first filename (which could be README)
+                return files[fallback];
 }
 function readme_(file, data, rm, cb) {
                 var rmfn = path.basename(rm);


### PR DESCRIPTION
This will prefer `README.md` and `README` (the former taking higher precedence) to any other `README.*` files. Note that there is no test case, as the current means of testing this uses the project root; if you would like me to change where the basic.js test case reads from, I can add a test case.

All existing tests continue to succeed.

I attempted to follow the existing coding style the best I could discern.
