### PR TITLE
updated to used scoped normalize-package-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "glob": "^4.0.2",
     "lru-cache": "2",
-    "normalize-package-data": "git://github.com/npm/normalize-package-data.git#othiym23/scoped"
+    "normalize-package-data": "^0.4.0"
   },
   "devDependencies": {
     "tap": "~0.2.5"


### PR DESCRIPTION
Needed for use by `npm.commands.publish`.
