### PR TITLE
Supports json5 syntax for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "github-url-from-git": "^1.3.0",
     "glob": "^4.0.2",
+    "json5": "^0.2.0",
     "lru-cache": "2",
     "normalize-package-data": "^1.0.0"
   },

--- a/read-json.js
+++ b/read-json.js
@@ -14,6 +14,7 @@ readJson.cache = new LRU({max: 1000})
 var path = require("path")
 var glob = require("glob")
 var normalizeData = require("normalize-package-data")
+var JSON5 = require('json5')
 
 // put more stuff on here to customize.
 readJson.extraSet = [
@@ -79,7 +80,7 @@ function parseJson (file, er, d, log, strict, cb) {
                 }
                 if (er) return cb(er);
                 try {
-                                d = JSON.parse(stripBOM(d))
+                                d = JSON5.parse(stripBOM(d))
                 } catch (er) {
                                 d = parseIndex(d)
                                 if (!d) return cb(parseError(er, file));
@@ -368,7 +369,7 @@ function parseIndex (data) {
                 data = data[0]
                 data = data.replace(/^\s*\*/mg, "")
                 try {
-                                return JSON.parse(data)
+                                return JSON5.parse(data)
                 } catch (er) {
                                 return null
                 }

--- a/test/fixtures/bom.json5
+++ b/test/fixtures/bom.json5
@@ -1,0 +1,7 @@
+﻿// This file is written in JSON5 syntax
+{
+    name: 'this',
+    description: 'file',
+    author: 'has <filename>',
+    version: '0.0.1'
+}

--- a/test/json5.js
+++ b/test/json5.js
@@ -1,0 +1,19 @@
+// vim: set softtabstop=16 shiftwidth=16:
+var tap = require("tap")
+var readJson = require("../")
+var path = require("path")
+var fs = require("fs")
+
+console.error("JSON5 test")
+tap.test("JSON5 test", function (t) {
+                var p = path.resolve(__dirname, "fixtures/bom.json5")
+                readJson(p, function (er, data) {
+                                if (er) throw er;
+                                p = path.resolve(__dirname, "fixtures/bom.json")
+                                readJson(p, function (er, data2) {
+                                                if (er) throw er;
+                                                t.deepEqual(data, data2)
+                                                t.end()
+                                })
+                })
+})


### PR DESCRIPTION
Hi.

I'd like to write an annotation in `package.json` for adding usage of my npm-run-scripts, so I added supporting [json5](http://json5.org/) syntax in `package.json`. Any thoughts on this please...?

Thanks.