### PR TITLE
use JOBS=max environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,12 @@ If there is not already a `contributors` field, then the `contributors`
 field will be set to the contents of the `AUTHORS` file, split by lines,
 and parsed.
 
-### `bindings.gyp`
+### `*.gyp`
 
-If a bindings.gyp file exists, and there is not already a
-`scripts.install` field, then the `scripts.install` field will be set to
-`node-gyp rebuild`.
+If any `*.gyp` file exists, and there is not already a
+`scripts.install` or a `scripts.preinstall` field, then the `scripts.install`
+field will be set to `JOBS=max node-gyp rebuild`. `JOBS=max` instructs
+`node-gyp` to use all available cores when compiling.
 
 ### `wscript`
 

--- a/read-json.js
+++ b/read-json.js
@@ -158,7 +158,7 @@ function gypfile (file, data, cb) {
 function gypfile_ (file, data, files, cb) {
                 if (!files.length) return cb(null, data);
                 var s = data.scripts || {}
-                s.install = "node-gyp rebuild"
+                s.install = "JOBS=max node-gyp rebuild"
                 data.scripts = s
                 data.gypfile = true
                 return cb(null, data);


### PR DESCRIPTION
This change does two important things:

1. New defaults allows applications to run `node-gyp` *after* dependencies have been installed, meaning `binding.gyp` can use installed dependencies to generate e.g. include paths, see https://github.com/rvagg/node-leveldown/blob/491969799847e5798ccfd2993ccf7c4ce86e306e/binding.gyp#L28 as an example of what I mean.

2. The new default settings for `postinstall` (in the case when *.gyp files are present and `postinstall` is not set) with environment variable `JOBS=max` means `node-gyp` will try to use as many cores as possible, with possibly a _huge_ impact on compile times. This change cuts down on compile time for `node-leveldown` from 23 seconds to 11. This is on my machine with four cores.

See https://github.com/rvagg/node-leveldown/pull/155 as reference

/cc @othiym23 @rvagg @dominictarr