### PR TITLE
Support comments in JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "glob": "^5.0.3",
     "json-parse-helpfulerror": "^1.0.2",
-    "normalize-package-data": "^2.0.0"
+    "normalize-package-data": "^2.0.0",
+    "strip-json-comments": "^1.0.2"
   },
   "devDependencies": {
     "standard": "^3.3.1",

--- a/read-json.js
+++ b/read-json.js
@@ -10,6 +10,7 @@ var path = require('path')
 var glob = require('glob')
 var normalizeData = require('normalize-package-data')
 var safeJSON = require('json-parse-helpfulerror')
+var stripJsonComments = require('strip-json-comments')
 
 module.exports = readJson
 
@@ -57,12 +58,18 @@ function stripBOM (content) {
   return content
 }
 
+function stripBOMAndComments (content) {
+  var bomLess = stripBOM(content)
+
+  return stripJsonComments(bomLess)
+}
+
 function parseJson (file, er, d, log, strict, cb) {
   if (er && er.code === 'ENOENT') return indexjs(file, er, log, strict, cb)
   if (er) return cb(er)
 
   try {
-    d = safeJSON.parse(stripBOM(d))
+    d = safeJSON.parse(stripBOMAndComments(d))
   } catch (er) {
     d = parseIndex(d)
     if (!d) return cb(parseError(er, file))
@@ -369,7 +376,7 @@ function parseIndex (data) {
   data = data.replace(/^\s*\*/mg, '')
 
   try {
-    return safeJSON.parse(data)
+    return safeJSON.parse(stripJsonComments(data))
   } catch (er) {
     return null
   }

--- a/test/fixtures/strippedComments.json
+++ b/test/fixtures/strippedComments.json
@@ -1,0 +1,6 @@
+{
+  "name": "this",
+  "description": "file",
+  "author": "has <filename>",
+  "version" : "0.0.1"
+}

--- a/test/fixtures/withcomments.json
+++ b/test/fixtures/withcomments.json
@@ -1,0 +1,6 @@
+{
+  "name": "this", // remember 0.1 + 0.2 != 0.3!
+  "description": "file",
+  "author": "has <filename>",
+  "version" : "0.0.1"
+}

--- a/test/withcomments.js
+++ b/test/withcomments.js
@@ -1,0 +1,16 @@
+var tap = require('tap')
+var readJson = require('../')
+var path = require('path')
+
+tap.test('Comments test', function (t) {
+  var p = path.resolve(__dirname, 'fixtures/withcomments.json')
+  readJson(p, function (er, data) {
+    if (er) throw er
+    p = path.resolve(__dirname, 'fixtures/strippedcomments.json')
+    readJson(p, function (er, data2) {
+      if (er) throw er
+      t.deepEqual(data, data2)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Use case:
```js
  "dependencies": {
    "jquery": "^1.9.1" // The version of jQuery we use is not on npm, this one is pulled in as a peerDependency
  },
  "devDependencies": {
    "extract-text-webpack-plugin": "^0.7.1" // 0.8.0 has broken ordering
  }
```

While https://github.com/npm/npm/issues/4482 has a suggestion to use `"//"` as key, I think the context provided by having the comment be right by what you're commenting on is better