### PR TITLE
Add ability to define binaries for different platforms

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -283,7 +283,8 @@ function getPlatformBins (bin) {
         break
 
       default:
-        if (bin.default) _bin = bin.default
+        if (bin[ process.platform ]) _bin = bin[ process.platform ]
+        else if (bin.default) _bin = bin.default
         break
     }
   }

--- a/read-json.js
+++ b/read-json.js
@@ -257,8 +257,8 @@ function bins (file, data, cb) {
 
   var m = data.directories && data.directories.bin
 
+  if (m) data.directories.bin = m = getBins(m)
   if (data.bin || !m) return cb(null, data)
-  data.directories.bin = m = getBins(data.directories.bin)
 
   m = path.resolve(path.dirname(file), m)
   glob('**', { cwd: m }, function (er, bins) {

--- a/read-json.js
+++ b/read-json.js
@@ -252,16 +252,56 @@ function mans_ (file, data, mans, cb) {
 }
 
 function bins (file, data, cb) {
+  if (data.bin) data.bin = getBins(data.bin)
   if (Array.isArray(data.bin)) return bins_(file, data, data.bin, cb)
 
   var m = data.directories && data.directories.bin
+
   if (data.bin || !m) return cb(null, data)
+  data.directories.bin = m = getBins(data.directories.bin)
 
   m = path.resolve(path.dirname(file), m)
   glob('**', { cwd: m }, function (er, bins) {
     if (er) return cb(er)
     bins_(file, data, bins, cb)
   })
+}
+
+function getPlatformBins (bin) {
+  var _bin
+
+  if (typeof (bin) === 'object' && bin) {
+    switch (process.platform) {
+      case 'win32':
+        if (bin.win32) _bin = bin.win32
+        else if (bin.windows) _bin = bin.windows
+        break
+
+      case 'darwin':
+        if (bin.osx) _bin = bin.osx
+        else if (bin.darwin) _bin = bin.darwin
+        break
+
+      default:
+        if (bin.default) _bin = bin.default
+        break
+    }
+  }
+
+  return _bin || bin.default || bin
+}
+
+function getBins (data) {
+  var ret,
+      isArray = true
+
+  if (!Array.isArray(data)) {
+    isArray = false
+    data = [ data ]
+  }
+
+  ret = data.map(getPlatformBins)
+  return (isArray) ? ret : ret[0]
 }
 
 function bins_ (file, data, bins, cb) {

--- a/test/bin.js
+++ b/test/bin.js
@@ -22,6 +22,16 @@ tap.test('Bin test', function (t) {
   })
 })
 
+tap.test('Bin directory test', function (t) {
+  var p = path.resolve(__dirname, 'fixtures/directory-bin.json')
+  var warn = createWarningCollector()
+  readJson(p, warn, function (er, data) {
+    t.equals(warn.warnings.length, 0)
+    t.deepEqual(data.bin, {'echo': 'bin/echo'})
+    t.end()
+  })
+})
+
 tap.test('Bad bin test', function (t) {
   var p = path.resolve(__dirname, 'fixtures/badbin.json')
   var warn = createWarningCollector()

--- a/test/fixtures/directory-bin.json
+++ b/test/fixtures/directory-bin.json
@@ -1,0 +1,17 @@
+{
+  "name": "bin-test",
+  "description": "my desc",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/npm/read-package-json.git"
+  },
+  "version": "0.0.1",
+  "readme": "hello world",
+  "directories": {
+    "bin": {
+      "win32": "./bin",
+      "default": "./bin"
+    }
+  },
+  "license": "ISC"
+}


### PR DESCRIPTION
Hi together,

I just noticed some days ago, that it is actually not possible to provide different kinds of binaries for different platforms. This gets especially useful, when one want to provide a shell script as bin on both, *nix like systems and windows systems, for example to pass the harmony parameter to the node executable, without being forced to create a workaround with `child_process.spawn`.

I just quickly build this feature, to be able to define different bins per platform, while ensuring that everything is backwards compatible. Also added one test already, but I wanted to wait with everything else (the rest of the test and adding details to the docs) until I heard your thoughts about this topic.

## Example
An example how a platform specific would be defined, looks like the following:

```json
{
  "name": "bin-test",
  "description": "my desc",
  "repository": {
    "type": "git",
    "url": "git://github.com/npm/read-package-json.git"
  },
  "version": "0.0.1",
  "readme": "hello world",
  "directories": {
    "bin": {
      "win32": "./win32_bin",
      "default": "./bin"
    }
  },
  "license": "ISC"
}
```

## Aliases

I also added the aliases osx and windows for win32 and darwin which might be more intuitive for the users.


Please share your thoughts if this is the way we should go, or if you would prefer to choose another direction.

Thanks