### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tap": "^1.2.0"
   },
   "optionalDependencies": {
-    "graceful-fs": "2 || 3"
+    "graceful-fs": "^4.1.2"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714