### PR TITLE
FIX don’t crash on non-string ‘bin’ entries

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -325,7 +325,7 @@ function checkBinReferences_ (file, data, warn, cb) {
       var binPath = path.resolve(dirName, relName)
       fs.exists(binPath, handleExists.bind(null, relName))
     } catch (error) {
-      if (error instanceof TypeError && error.message === 'Arguments to path.resolve must be strings') {
+      if (error instanceof TypeError && (error.message === 'Arguments to path.resolve must be strings' || error.message.indexOf('Path must be a string') === 0)) {
         keysLeft--
         if (!keysLeft) cb()
       } else {

--- a/read-json.js
+++ b/read-json.js
@@ -321,8 +321,17 @@ function checkBinReferences_ (file, data, warn, cb) {
   keys.forEach(function (key) {
     var dirName = path.dirname(file)
     var relName = data.bin[key]
-    var binPath = path.resolve(dirName, relName)
-    fs.exists(binPath, handleExists.bind(null, relName))
+    try {
+      var binPath = path.resolve(dirName, relName)
+      fs.exists(binPath, handleExists.bind(null, relName))
+    } catch (error) {
+      if (error instanceof TypeError && error.message === 'Arguments to path.resolve must be strings') {
+        keysLeft--
+        if (!keysLeft) cb()
+      } else {
+        throw error
+      }
+    }
   })
 }
 

--- a/test/bin-non-string.js
+++ b/test/bin-non-string.js
@@ -1,0 +1,10 @@
+var tap = require('tap')
+var readJson = require('../')
+var path = require('path')
+var p = path.resolve(__dirname, 'fixtures/badbinnonstring.json')
+
+tap.test('non-string bin entries', function (t) {
+  readJson(p, function (er, data) {
+    t.end()
+  })
+})

--- a/test/fixtures/badbinnonstring.json
+++ b/test/fixtures/badbinnonstring.json
@@ -1,0 +1,14 @@
+{
+  "name": "badbinnonstring-test",
+  "description": "my desc",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/npm/read-package-json.git"
+  },
+  "version": "0.0.1",
+  "readme": "hello world",
+  "bin": {
+    "key": {}
+  },
+  "license": "ISC"
+}


### PR DESCRIPTION
I've run read-package-json against every version of every package on npm and discovered an edge case where it throws an uncatchable exception when `bin` entry of package.json isn't a string. The exception stack trace is:

```
TypeError: Arguments to path.resolve must be strings
    at Object.posix.resolve (path.js:439:13)
    at /root/normalize-package-jsons/node_modules/read-package-json/read-json.js:324:24
    at Array.forEach (native)
    at checkBinReferences_ (/root/normalize-package-jsons/node_modules/read-package-json/read-json.js:321:8)
    at final (/root/normalize-package-jsons/node_modules/read-package-json/read-json.js:343:3)
    at then (/root/normalize-package-jsons/node_modules/read-package-json/read-json.js:113:5)
    at /root/normalize-package-jsons/node_modules/read-package-json/read-json.js:284:20
    at /root/normalize-package-jsons/node_modules/read-package-json/node_modules/graceful-fs/graceful-fs.js:76:16
    at fs.js:263:20
    at FSReqWrap.oncomplete (fs.js:95:15)
```

Here's a [repro online](https://tonicdev.com/rentzsch/561c6c66a8eef00c00e44c4d). That one old version of `mstrwebci` is just one example, there's other problematic versions of this package and other packages.

This Pull Request catches the exact exception and simply ignores the bin key. It could be made better to warn about the issue, but for our use on https://tonicdev.com we don't need fine-grained warnings (we just clean up bad package.json's to make them usable if possible).

Passing test included.
