### PR TITLE
standard@^5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "normalize-package-data": "^2.0.0"
   },
   "devDependencies": {
-    "standard": "^3.3.1",
+    "standard": "^5.3.1",
     "tap": "^1.2.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Only one failure:

``` sh
$ npm t

> read-package-json@2.0.1 test /home/kenan/Code/forks/read-package-json
> standard && tap test/*.js

standard: Use JavaScript Standard Style (https://github.com/feross/standard) 
  /home/kenan/Code/forks/read-package-json/test/readmes.js:9:5: "expect" is already defined
npm ERR! Test failed.  See above for more details.

```

which https://github.com/npm/read-package-json/pull/53 would fix :)