### PR TITLE
add support for READMEs in deep paths

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -193,6 +193,7 @@ function authors_ (file, data, ad, cb) {
 function readme (file, data, cb) {
   if (data.readme) return cb(null, data)
   var dir = path.dirname(file)
+  if (data.readmeFilename) return readme_(file, data, path.resolve(dir, data.readmeFilename), cb)
   var globOpts = { cwd: dir, nocase: true, mark: true }
   glob('{README,README.*}', globOpts, function (er, files) {
     if (er) return cb(er)
@@ -228,7 +229,7 @@ function readme_ (file, data, rm, cb) {
     // maybe not readable, or something.
     if (er) return cb()
     data.readme = rm
-    data.readmeFilename = rmfn
+    if (!data.readmeFilename) data.readmeFilename = rmfn
     return cb(er, data)
   })
 }

--- a/test/fixtures/nested-readme/foo/README.md
+++ b/test/fixtures/nested-readme/foo/README.md
@@ -1,0 +1,1 @@
+*markdown*

--- a/test/fixtures/nested-readme/package.json
+++ b/test/fixtures/nested-readme/package.json
@@ -1,0 +1,1 @@
+{"name":"nested-readme", "version":"99.999.999999999", "readmeFilename":"foo/README.md"}

--- a/test/nested-readme.js
+++ b/test/nested-readme.js
@@ -1,0 +1,27 @@
+var path = require('path')
+
+var tap = require('tap')
+var p = path.resolve(__dirname, 'fixtures/nested-readme/package.json')
+
+var readJson = require('../')
+
+var expect = {
+  'name': 'nested-readme',
+  'version': '99.999.999999999',
+  'readme': '*markdown*\n',
+  'readmeFilename': 'foo/README.md',
+  'description': '*markdown*',
+  '_id': 'nested-readme@99.999.999999999'
+}
+
+tap.test('readme test', function (t) {
+  readJson(p, function (er, data) {
+    t.ifError(er, 'read README without error')
+    test(t, data)
+  })
+})
+
+function test (t, data) {
+  t.deepEqual(data, expect)
+  t.end()
+}


### PR DESCRIPTION
This currently uses the `readmeFilename` key on `package.json` to add support for READMEs in deep paths with minimal changes.

My understanding from checking out `fstream-npm` is that [readme files should never be ignored](https://github.com/npm/fstream-npm/blob/d57b6b24f91156067f73417dd8785c6312bfc75f/fstream-npm.js#L96-L97), so the file should exist in the package. I added a `foo/README.md` test fixture to `fstream-npm` to confirm this, can pull request if desired.

Fixes https://github.com/npm/npm/issues/9481

/cc @othiym23
