### PR TITLE
Feature: change `cwd` for `npm run scriptname`

### DIFF
--- a/test/advanced.js
+++ b/test/advanced.js
@@ -1,0 +1,30 @@
+var path = require('path')
+var tap = require('tap')
+var readJson = require('../')
+
+tap.test('script cwd test', function (t) {
+  var p = path.resolve(__dirname, 'fixtures/scripts.json')
+  readJson(p, function (er, data) {
+    if (er) throw er
+    advanced_(t, data)
+  })
+})
+
+function advanced_ (t, data) {
+  var testCmdName = 'change-cwd-test'
+  var changeCwdPath = 'test/fixtures/'
+  var cmdValue = 'node -e \"console.log(process.cwd())\"'
+
+  var newPropName = '_cwdChanges'
+  var newPropValue = {
+    'cmd': testCmdName,
+    'cwd': changeCwdPath,
+    'run': cmdValue
+  }
+
+  t.ok(data)
+  t.ok(data.scripts.hasOwnProperty(newPropName))
+  t.deepEqual(data.scripts[newPropName][0], newPropValue)
+  t.deepEqual(data.scripts[testCmdName], cmdValue)
+  t.end()
+}

--- a/test/fixtures/scripts.json
+++ b/test/fixtures/scripts.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "change-cwd-test": {
+      "cwd": "test/fixtures/",
+      "run": "node -e \"console.log(process.cwd())\""
+      }
+  }
+}


### PR DESCRIPTION
ISSUE in npm: https://github.com/npm/npm/issues/10957
PR in npm: https://github.com/npm/npm/issues/10958

This commit adds the above mentioned feature by checking whether the package
JSON includes a script in the form of...

```
{
    "scripts": {
      "change-cwd-test": {
         "cwd": "test/fixtures/",
         "run": "node -e \"console.log(process.cwd())\""
     }
   }
}
```

It then attaches a un-enumerable array to the `scripts` objects, which the `npm`
client can check for during execution.
From the `npm` client's POV, this seems a little odd since it needs to transform
a lot. But in order to pass hard checks here and w/ `npm` and not to break, this
seemed to be necessary for the author.

**Background:**
This described in greater detail in the above mentioned issue and PR in the `npm`-repo. Fundamentally though, this for enabling `npm` to be more
of a build tool. For example some programs such as make don't allow non-cwd
runs. And in order to not `cd` to it, this is supposed to greatly help.