### PR TITLE
Populate contributors arrays from AUTHORS directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "glob": "^6.0.0",
     "json-parse-helpfulerror": "^1.0.2",
+    "map-async": "^0.1.1",
     "normalize-package-data": "^2.0.0"
   },
   "devDependencies": {

--- a/test/authors-directory.js
+++ b/test/authors-directory.js
@@ -1,0 +1,37 @@
+var path = require('path')
+
+var tap = require('tap')
+var p = path.resolve(__dirname, 'fixtures/authors-directory/package.json')
+
+var readJson = require('../')
+
+var expect = {
+  'name': 'authors-directory',
+  'version': '1.0.0',
+  'contributors': [
+    {
+      'name': 'Bill Author',
+      'email': 'bill@author.com'
+    },
+    {
+      'name': 'Jane Author',
+      'email': 'jane@author.com'
+    }
+  ],
+  'description': 'Some README',
+  'readme': 'Some README\n',
+  'readmeFilename': 'README',
+  '_id': 'authors-directory@1.0.0'
+}
+
+tap.test('AUTHORS directory test', function (t) {
+  readJson(p, function (er, data) {
+    t.ifError(er, 'read AUTHORS without error')
+    test(t, data)
+  })
+})
+
+function test (t, data) {
+  t.deepEqual(data, expect)
+  t.end()
+}

--- a/test/authors-file.js
+++ b/test/authors-file.js
@@ -1,0 +1,33 @@
+var path = require('path')
+
+var tap = require('tap')
+var p = path.resolve(__dirname, 'fixtures/authors-file/package.json')
+
+var readJson = require('../')
+
+var expect = {
+  'name': 'authors-file',
+  'version': '1.0.0',
+  'contributors': [
+    {
+      'name': 'Jane Author',
+      'email': 'jane@author.com'
+    }
+  ],
+  'description': 'Some README',
+  'readme': 'Some README\n',
+  'readmeFilename': 'README',
+  '_id': 'authors-file@1.0.0'
+}
+
+tap.test('AUTHORS file test', function (t) {
+  readJson(p, function (er, data) {
+    t.ifError(er, 'read AUTHORS without error')
+    test(t, data)
+  })
+})
+
+function test (t, data) {
+  t.deepEqual(data, expect)
+  t.end()
+}

--- a/test/fixtures/authors-directory/AUTHORS/bill
+++ b/test/fixtures/authors-directory/AUTHORS/bill
@@ -1,0 +1,1 @@
+Bill Author <bill@author.com>

--- a/test/fixtures/authors-directory/AUTHORS/jane
+++ b/test/fixtures/authors-directory/AUTHORS/jane
@@ -1,0 +1,1 @@
+Jane Author <jane@author.com>

--- a/test/fixtures/authors-directory/README
+++ b/test/fixtures/authors-directory/README
@@ -1,0 +1,1 @@
+Some README

--- a/test/fixtures/authors-directory/package.json
+++ b/test/fixtures/authors-directory/package.json
@@ -1,0 +1,1 @@
+{"name":"authors-directory", "version": "1.0.0"}

--- a/test/fixtures/authors-file/AUTHORS
+++ b/test/fixtures/authors-file/AUTHORS
@@ -1,0 +1,1 @@
+Jane Author <jane@author.com>

--- a/test/fixtures/authors-file/README
+++ b/test/fixtures/authors-file/README
@@ -1,0 +1,1 @@
+Some README

--- a/test/fixtures/authors-file/package.json
+++ b/test/fixtures/authors-file/package.json
@@ -1,0 +1,1 @@
+{"name":"authors-file", "version": "1.0.0"}


### PR DESCRIPTION
This pull request adds a new way to populate contributors arrays from the file system.

In pseudocode, current to proposed:

``` diff
  IF there's no contributors array in package.json
    IF AUTHORS is a file
      read it and populate contributors
+   ELSE IF AUTHORS is a directory
+     read its files and populate contributors
```

`AUTHORS` is a super neat idea, but as an append-only file, it creates merge conflicts when, say, multiple pull requests each add a different new contributor's information to the end of the same AUTHORS file.

The Unix-hermit, command-line way to address this is to tell Git to use a different merge strategy:

```
AUTHORS merge=union
```

Such files feel like cruft, and GitHub won't apply them, making pushbutton merges impossible. (See isaacs/github#487.) Apparently folks like pushing the button.

An AUTHORS directory of files containing AUTHORS text solves the problem by adding files to a directory (a set) instead of appending lines to a file (a list). Folks might use their GitHub handles as filenames, for instance, and include comment lines to summarize what they've 
contributed.

There are some potentially neat applications, like my own https://github.com/berneout/per-contributor-certificate-test.

Thanks to all!
