### PR TITLE
Allow multiple lines for the `scripts` directive.

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -124,7 +124,13 @@ function scriptpath (file, data, cb) {
 function scriptpath_ (key) {
   var s = this[key]
   // This is never allowed, and only causes problems
-  if (typeof s !== 'string') return delete this[key]
+  if (typeof s !== 'string') {
+    // easier to maintain and write sh via
+    // multiple lines joined via \n
+    if (!Array.isArray(s)) return delete this[key]
+    this[key] = s.join('\n')
+    s = this[key]
+  }
 
   var spre = /^(\.[\/\\])?node_modules[\/\\].bin[\\\/]/
   if (s.match(spre)) {


### PR DESCRIPTION
Writing long lines of sh/bash is not easy to maintain.
Allowing within the `scripts` section also an Array
would make it easier to read, write, and maintain
more complex tasks based on `npm run task`
