### PR TITLE
Fall back to .git/packed-refs if .git/<ref> does not exist

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -302,10 +302,26 @@ function githead_ (file, data, dir, head, cb) {
     data.gitHead = head.trim()
     return cb(null, data)
   }
-  var headFile = head.replace(/^ref: /, '').trim()
-  headFile = path.resolve(dir, '.git', headFile)
+  var headRef = head.replace(/^ref: /, '').trim()
+  var headFile = path.resolve(dir, '.git', headRef)
   fs.readFile(headFile, 'utf8', function (er, head) {
-    if (er || !head) return cb(null, data)
+    if (er || !head) {
+      var packFile = path.resolve(dir, '.git/packed-refs')
+      return fs.readFile(packFile, 'utf8', function (er, refs) {
+        if (er || !refs) {
+          return cb(null, data)
+        }
+        refs = refs.split('\n')
+        for (var i = 0; i < refs.length; i++) {
+          var match = refs[i].match(/^([0-9a-f]{40}) (.+)$/)
+          if (match && match[2].trim() === headRef) {
+            data.gitHead = match[1]
+            break
+          }
+        }
+        return cb(null, data)
+      })
+    }
     head = head.replace(/^ref: /, '').trim()
     data.gitHead = head
     return cb(null, data)


### PR DESCRIPTION
When running `npm publish` in a repo with its refs packed, the `gitHead` property is not filled.

This change falls back to searching `.git/packed-refs` if the ref is not found in its own file under `.git`.
