### PR TITLE
20% npm install speedup: cache extras by package.json string

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -26,6 +26,7 @@ readJson.extraSet = [
 ]
 
 var typoWarned = {}
+var cache = {}
 
 function readJson (file, log_, strict_, cb_) {
   var log, strict, cb
@@ -72,14 +73,27 @@ function parseJson (file, er, d, log, strict, cb) {
   }
   if (er) return cb(er)
 
+  if (cache[d]) return cb(null, cache[d])
+
+  var data
+
   try {
-    d = safeJSON.parse(stripBOM(d))
+    data = safeJSON.parse(stripBOM(d))
   } catch (er) {
-    d = parseIndex(d)
-    if (!d) return cb(parseError(er, file))
+    data = parseIndex(d)
+    if (!data) return cb(parseError(er, file))
   }
 
-  extras(file, d, log, strict, cb)
+  extrasCached(file, d, data, log, strict, cb)
+}
+
+function extrasCached (file, d, data, log, strict, cb) {
+  extras(file, data, log, strict, (err, data) => {
+    if (!err) {
+      cache[d] = data
+    }
+    cb(err, data)
+  })
 }
 
 function indexjs (file, er, log, strict, cb) {
@@ -89,10 +103,12 @@ function indexjs (file, er, log, strict, cb) {
   fs.readFile(index, 'utf8', function (er2, d) {
     if (er2) return cb(er)
 
-    d = parseIndex(d)
-    if (!d) return cb(er)
+    if (cache[d]) return cb(null, cache[d])
 
-    extras(file, d, log, strict, cb)
+    var data = parseIndex(d)
+    if (!data) return cb(er)
+
+    extrasCached(file, d, data, log, strict, cb)
   })
 }
 


### PR DESCRIPTION
## TL:DR
~20% speed up in the average npm install run when combined with https://github.com/npm/hosted-git-info/pull/24

## Details
This package used to actually cache package.json lookups, until https://github.com/npm/read-package-json/commit/b746f651da96aedca33e1f0e08c305ed055c417d which was an attempt to fix https://github.com/npm/npm/issues/7074 Deleting the caching mechanism definitely helped fix a correctness issue, but threw the baby out with the bath water. This PR introduces a less aggressive cache by caching by the *true* cache key, which is the string contents of a package.json file. Should be 100% safe to cache results based on this... I believe.

This lets us speed up builds quite a bit!

### Before:
```
added 1764 packages in 51.943s
added 1764 packages in 51.135s
added 1764 packages in 50.688s
added 1764 packages in 52.048s
added 1764 packages in 52.156s
added 1764 packages in 54.817s
```
### After
```
added 1764 packages in 42.428s
added 1764 packages in 45.116s
added 1764 packages in 42.085s
```

Let me know if you have any questions