### PR TITLE
Upgrade slash, drop Node 4 support, test Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - '6'
   - '8'
+  - '10'
 sudo: false
 before_install:
   - npm install -g npm@latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - '6'
-  - '4'
   - '8'
 sudo: false
 before_install:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4946,9 +4946,9 @@
       "dev": true
     },
     "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
     },
     "slice-ansi": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/npm/read-package-json.git"
   },
+  "engines": {
+    "node": "> 4"
+  },
   "main": "read-json.js",
   "scripts": {
     "prerelease": "npm t",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glob": "^7.1.1",
     "json-parse-better-errors": "^1.0.1",
     "normalize-package-data": "^2.0.0",
-    "slash": "^1.0.0"
+    "slash": "^2.0.0"
   },
   "devDependencies": {
     "standard": "^11.0.0",


### PR DESCRIPTION
The 2.0 version requires Node.js 6, but unlike 1.0, the npm package now contains a full license text. Without a full license text it is a problematic dependency in some legal environments (the MIT license itself requires the full license text attached in the npm distribution).

Although the package now requires Node 6, there are no changes preventing it to run on Node 4 as well: https://github.com/sindresorhus/slash/commit/6fd50ff0bcb68812df18d526c0c3d5740fd13382