### PR TITLE
support bundleDependencies: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/npm/read-package-json/compare/v2.0.13...v2.1.0) (2019-08-13)
+
+
+### Features
+
+* support bundleDependencies: true ([76f6f42](https://github.com/npm/read-package-json/commit/76f6f42))
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/npm/read-package-json/compare/v2.0.12...v2.0.13) (2018-03-08)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "read-package-json",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "read-package-json",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "description": "The thing npm uses to read package.json files with semantics and defaults and validation",
   "repository": {

--- a/read-json.js
+++ b/read-json.js
@@ -403,17 +403,16 @@ function checkBinReferences_ (file, data, warn, cb) {
   keys.forEach(function (key) {
     var dirName = path.dirname(file)
     var relName = data.bin[key]
-    try {
-      var binPath = path.resolve(dirName, relName)
-      fs.stat(binPath, (err) => handleExists(relName, !err))
-    } catch (error) {
-      if (error.message === 'Arguments to path.resolve must be strings' || error.message.indexOf('Path must be a string') === 0) {
-        warn('Bin filename for ' + key + ' is not a string: ' + util.inspect(relName))
-        handleExists(relName, true)
-      } else {
-        cb(error)
-      }
+    if (typeof relName !== 'string') {
+      var msg = 'Bin filename for ' + key +
+        ' is not a string: ' + util.inspect(relName)
+      warn(msg)
+      delete data.bin[key]
+      handleExists(relName, true)
+      return
     }
+    var binPath = path.resolve(dirName, relName)
+    fs.stat(binPath, (err) => handleExists(relName, !err))
   })
 }
 

--- a/read-json.js
+++ b/read-json.js
@@ -17,6 +17,7 @@ module.exports = readJson
 
 // put more stuff on here to customize.
 readJson.extraSet = [
+  bundleDependencies,
   gypfile,
   serverjs,
   scriptpath,
@@ -321,6 +322,23 @@ function bins_ (file, data, bins, cb) {
     }
     return acc
   }, {})
+  return cb(null, data)
+}
+
+function bundleDependencies (file, data, cb) {
+  var bd = 'bundleDependencies'
+  var bdd = 'bundledDependencies'
+  // normalize key name
+  if (data[bdd] !== undefined) {
+    if (data[bd] === undefined) data[bd] = data[bdd]
+    delete data[bdd]
+  }
+  if (data[bd] === false) delete data[bd]
+  else if (data[bd] === true) {
+    data[bd] = Object.keys(data.dependencies || {})
+  } else if (data[bd] !== undefined && !Array.isArray(data[bd])) {
+    delete data[bd]
+  }
   return cb(null, data)
 }
 

--- a/test/bin-non-string.js
+++ b/test/bin-non-string.js
@@ -5,9 +5,11 @@ var p = path.resolve(__dirname, 'fixtures/badbinnonstring.json')
 
 tap.test('non-string bin entries', function (t) {
   var logmsgs = []
-  readJson(p, function (msg) { logmsgs.push([].slice.call(arguments)) }, function (er, data) {
-    t.comment(logmsgs.map(function (msg) { return 'Warning: ' + msg.join(' ') }).join('\n'))
+  const warn = (...msg) => logmsgs.push(msg)
+  readJson(p, warn, function (er, data) {
+    t.comment(logmsgs.map(msg => 'Warning: ' + msg.join(' ')).join('\n'))
     t.like(er, null, 'no error from readJson')
+    t.same(data.bin, {})
     t.end()
   })
 })

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -1,0 +1,68 @@
+const t = require('tap')
+const read = require('../')
+const { resolve } = require('path')
+
+t.test('bundle-true', t => {
+  const fixture = resolve(__dirname, 'fixtures/bundle-true.json')
+  read(fixture, (er, data) => {
+    if (er) {
+      throw er
+    }
+    t.match(data, {
+      name: 'bundletrue',
+      version: '1.2.3',
+      dependencies: { a: '', b: '' },
+      optionalDependencies: { b: '' },
+      devDependencies: { c: '' },
+      bundleDependencies: [ 'a' ],
+      readme: 'ERROR: No README data found!',
+      _id: 'bundletrue@1.2.3'
+    })
+    t.end()
+  })
+})
+
+t.test('bundle-null', t => {
+  const fixture = resolve(__dirname, 'fixtures/bundle-null.json')
+  read(fixture, (er, data) => {
+    if (er) {
+      throw er
+    }
+    t.notOk(data.bundleDependencies, 'no bundleDependencies')
+    t.notOk(data.bundledDependencies, 'no bundledDependencies')
+    t.end()
+  })
+})
+
+t.test('bundle-array', t => {
+  const fixture = resolve(__dirname, 'fixtures/bundle-array.json')
+  read(fixture, (er, data) => {
+    t.match(data, {
+      name: 'bundlearray',
+      version: '1.2.3',
+      dependencies: { a: '', b: '', c: '*' },
+      optionalDependencies: { b: '' },
+      devDependencies: { c: '' },
+      bundleDependencies: [ 'a', 'b', 'c' ],
+      readme: 'ERROR: No README data found!',
+      _id: 'bundlearray@1.2.3'
+    })
+    t.end()
+  })
+})
+
+t.test('bundle-false', t => {
+  const fixture = resolve(__dirname, 'fixtures/bundle-false.json')
+  read(fixture, (er, data) => {
+    t.match(data, {
+      name: 'bundlefalse',
+      version: '1.2.3',
+      dependencies: { a: '', b: '' },
+      optionalDependencies: { b: '' },
+      devDependencies: { c: '' },
+      readme: 'ERROR: No README data found!',
+      _id: 'bundlefalse@1.2.3'
+    })
+    t.end()
+  })
+})

--- a/test/fixtures/bundle-array.json
+++ b/test/fixtures/bundle-array.json
@@ -1,0 +1,18 @@
+{
+  "name": "bundlearray",
+  "version": "1.2.3",
+  "dependencies": {
+    "a": ""
+  },
+  "optionalDependencies": {
+    "b": ""
+  },
+  "devDependencies": {
+    "c": ""
+  },
+  "bundledDependencies": [
+    "a",
+    "b",
+    "c"
+  ]
+}

--- a/test/fixtures/bundle-false.json
+++ b/test/fixtures/bundle-false.json
@@ -1,0 +1,15 @@
+{
+  "name": "bundlefalse",
+  "version": "1.2.3",
+  "dependencies": {
+    "a": ""
+  },
+  "optionalDependencies": {
+    "b": ""
+  },
+  "devDependencies": {
+    "c": ""
+  },
+  "bundleDependencies": false,
+  "bundledDependencies": true
+}

--- a/test/fixtures/bundle-null.json
+++ b/test/fixtures/bundle-null.json
@@ -1,0 +1,15 @@
+{
+  "name": "bundlenull",
+  "version": "1.2.3",
+  "dependencies": {
+    "a": ""
+  },
+  "optionalDependencies": {
+    "b": ""
+  },
+  "devDependencies": {
+    "c": ""
+  },
+  "bundleDependencies": null,
+  "bundledDependencies": true
+}

--- a/test/fixtures/bundle-true.json
+++ b/test/fixtures/bundle-true.json
@@ -1,0 +1,14 @@
+{
+  "name": "bundletrue",
+  "version": "1.2.3",
+  "dependencies": {
+    "a": ""
+  },
+  "optionalDependencies": {
+    "b": ""
+  },
+  "devDependencies": {
+    "c": ""
+  },
+  "bundledDependencies": true
+}

--- a/test/fixtures/indexjs-bad/index.js
+++ b/test/fixtures/indexjs-bad/index.js
@@ -1,0 +1,14 @@
+/**package
+ * {
+ *   "name": "indexjs-test",
+ *   "version": "1.2.3",
+ *   "description": "Did you know npm could do this, even?",
+ *   "main": "index.js"
+ *
+ *   but alas, 'twas not to be,
+ *   for, when parse the comment we,
+ *   json is not there to see
+ *
+ * }
+ **/
+console.log('just a broken single-file package')

--- a/test/fixtures/indexjs/index.js
+++ b/test/fixtures/indexjs/index.js
@@ -1,0 +1,9 @@
+/**package
+ * {
+ *   "name": "indexjs-test",
+ *   "version": "1.2.3",
+ *   "description": "Did you know npm could do this, even?",
+ *   "main": "index.js"
+ * }
+ **/
+console.log('just a simple single-file package')

--- a/test/fixtures/invalid-version/package.json
+++ b/test/fixtures/invalid-version/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "bob-the-cat",
+  "version": "a live bobcat",
+  "description": "instead of semver, package contained live bobcat"
+}

--- a/test/indexjs.js
+++ b/test/indexjs.js
@@ -1,0 +1,32 @@
+const t = require('tap')
+const read = require('../')
+const { resolve } = require('path')
+t.test('read from an index.js file', t => {
+  const fixture = resolve(__dirname, 'fixtures/indexjs/package.json')
+  read(fixture, (er, data) => {
+    if (er) {
+      throw er
+    }
+    t.match(data, {
+      name: 'indexjs-test',
+      version: '1.2.3',
+      description: 'Did you know npm could do this, even?',
+      main: 'index.js',
+      readme: 'ERROR: No README data found!',
+      _id: 'indexjs-test@1.2.3'
+    })
+    t.end()
+  })
+})
+
+t.test('read broken json', t => {
+  const fixture = resolve(__dirname, 'fixtures/indexjs-bad/package.json')
+  read(fixture, (er, data) => {
+    t.match(er, {
+      code: 'ENOENT',
+      path: fixture
+    })
+    t.notOk(data)
+    t.end()
+  })
+})

--- a/test/semver.js
+++ b/test/semver.js
@@ -1,0 +1,13 @@
+const t = require('tap')
+const readJson = require('../')
+const path = require('path')
+const file = path.resolve(__dirname, 'fixtures/invalid-version/package.json')
+const logs = []
+const warn = (...msg) => logs.push(msg)
+readJson(file, warn, false, (er, data) => {
+  t.match(er, {
+    message: 'Invalid version: "a live bobcat"'
+  })
+  t.notOk(data)
+  t.end()
+})


### PR DESCRIPTION
What ends up in the parsed output is still an array of names, but we
generate that name from the keys if it's set to true.

Also, avoid the footgun of people not realizing that bundleDependencies
should be an array of names, rather than a {name:versoin} object.

BREAKING CHANGE: raise an error if bundleDependencies is something other
than a boolean or Array.