### PR TITLE
BREAKING CHANGE: rename file attribute to path

### DIFF
--- a/read-json.js
+++ b/read-json.js
@@ -469,6 +469,6 @@ function parseIndex (data) {
 function parseError (ex, file) {
   var e = new Error('Failed to parse json\n' + ex.message)
   e.code = 'EJSONPARSE'
-  e.file = file
+  e.path = file
   return e
 }

--- a/test/fixtures/indexjs-bad/package.json
+++ b/test/fixtures/indexjs-bad/package.json
@@ -1,0 +1,3 @@
+{"this is
+
+  Not valid json!!

--- a/test/indexjs.js
+++ b/test/indexjs.js
@@ -19,11 +19,24 @@ t.test('read from an index.js file', t => {
   })
 })
 
-t.test('read broken json', t => {
-  const fixture = resolve(__dirname, 'fixtures/indexjs-bad/package.json')
+t.test('missing file', t => {
+  // this subdirectory does not exist
+  const fixture = resolve(__dirname, 'fixtures/indexjs-missing/package.json')
   read(fixture, (er, data) => {
     t.match(er, {
       code: 'ENOENT',
+      path: fixture
+    })
+    t.notOk(data)
+    t.end()
+  })
+})
+
+t.test('EJSONPARSE', t => {
+  const fixture = resolve(__dirname, 'fixtures/indexjs-bad/package.json')
+  read(fixture, (er, data) => {
+    t.match(er, {
+      code: 'EJSONPARSE',
       path: fixture
     })
     t.notOk(data)


### PR DESCRIPTION
fix(parseError): use file not path attribute

In order to align with the way our other "fast" json parsers work the
err.file attribute needs to be renamed to err.path.

Also other errors i.e. ENOENT attach a path attribute.