### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,58 +1,11 @@
 {
-  "name": "read-package-json",
-  "version": "6.0.1",
-  "author": "GitHub Inc.",
-  "description": "The thing npm uses to read package.json files with semantics and defaults and validation",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/npm/read-package-json.git"
-  },
-  "main": "lib/read-json.js",
+  "name": "boxing-tv-david-benavidez-vs-caleb-plant-4k-live-free",
+  "version": "1.0.0",
+  "description": "2 minutes ago -The boxing calendar for 2023 is filling out nicely and fans are eagerly anticipating Saturday’s super middleweight shootout between former world champions David Benavidez and Caleb Plant, which takes place at the MGM Grand in Las Vegas. The 12-round bout, plus undercard action, will be broadcast on Showtime PPV.",
+  "main": "index.js",
   "scripts": {
-    "prerelease": "npm t",
-    "postrelease": "npm publish && git push --follow-tags",
-    "release": "standard-version -s",
-    "test": "tap",
-    "npmclilint": "npmcli-lint",
-    "lint": "eslint \"**/*.js\"",
-    "lintfix": "npm run lint -- --fix",
-    "posttest": "npm run lint",
-    "postsnap": "npm run lintfix --",
-    "postlint": "template-oss-check",
-    "snap": "tap",
-    "template-oss-apply": "template-oss-apply --force"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
-    "glob": "^9.3.0",
-    "json-parse-even-better-errors": "^3.0.0",
-    "normalize-package-data": "^5.0.0",
-    "npm-normalize-package-bin": "^3.0.0"
-  },
-  "devDependencies": {
-    "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.12.0",
-    "tap": "^16.0.1"
-  },
-  "license": "ISC",
-  "files": [
-    "bin/",
-    "lib/"
-  ],
-  "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-  },
-  "tap": {
-    "branches": 68,
-    "functions": 74,
-    "lines": 74,
-    "statements": 74,
-    "nyc-arg": [
-      "--exclude",
-      "tap-snapshots/**"
-    ]
-  },
-  "templateOSS": {
-    "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.12.0"
-  }
+  "author": "",
+  "license": "ISC"
 }


### PR DESCRIPTION
<!-- [Live'Stream**] Caleb Plant vs. David Benavidez Fight Live Broadcast Tv ON Coverage 25 March 2023 -->
<!-- How to watch Benavidez vs Plant: Live stream, TV channel, PPV price for boxing tonight

David Benavidez and Caleb Plant lock horns in a fiery super-middleweight fight in Las Vegas tonight.

[🔴📺LIVE📲👉 Benavidez vs Plant Live](https://benavidez-vs-plant.blogspot.com/2023/03/boxing-tv.html)

<a href="https://benavidez-vs-plant.blogspot.com/2023/03/boxing-tv.html" rel="noopener nofollow"><img src="https://livetv.wtvpc.com/wp-content/uploads/2017/06/tv-image.gif"></a>

The undefeated Benavidez, 26-0 with 23 knockouts, defends the WBC interim title that he claimed with a dominant early stoppage of David Lemieux for the first time as he eyes a future shot at boxing superstar Canelo Alvarez.

But the two-time full WBC champion is likely to face his toughest test to date against former IBF title-holder Plant, who is on the comeback trail after his own knockout defeat by Canelo in a massive undisputed clash back in 2021.

Having knocked out the ageing Anthony Dirrell in brutal fashion in October, ‘Sweethands’ is ready for another significant challenge at the MGM Grand Garden Arena tonight as he tries to inflict a first career loss on the hugely talented Benavidez in what is a huge grudge match.

How to watch Benavidez vs Plant

TV channel: In the UK, Benavidez vs Plant is being broadcast live via American digital video streaming service Fite TV. You can purchase the fight for $12.99 (£10.56).

Live stream: Once purchased, fans can watch the event live via the Fite TV website or app.

In the United States, the card is a Showtime pay-per-view that costs $74.99 to buy.

Benavidez vs Caleb Plant live stream: how to watch WBC boxing online, ringwalk time, TV channel

Benavidez vs Caleb Plant is live on Showtime as a PPV in the States. Fans in the UK and Canada are looking at a Fite PPV, while viewers in Australia can purchase it through Kayo Sports Main Event. Use a VPN to watch your usual stream while abroad(opens in new tab). Full details on how to watch Benavidez vs Caleb Plant on TV just below.

Modern boxing is dominated by vacuous bravado and highly processed "beefs", but the interim WBC super middleweight title fight between long-term adversaries and former division champions David Benavidez and Caleb Plant is the real deal.

Benavidez, the current holder of the belt, became the youngest champion in super middleweight history in 2017. Though he remains undefeated, the Mexican Monster has been stripped of the title twice, and it's no exaggeration to say that the trajectory of his career has shaped the entire division.

In a parallel universe, the 26-year-old might be the undisputed champion at 168lb rather than Canelo, who beat Plant in their unification bout in 2021 but is yet to face his compatriot in the ring. 

If Benavidez gets the better of Plant at the MGM Grand, the blockbuster Canelo showdown that we've waited years for will finally, finally be on the cards.

That's exactly the kind of talk that Plant has had to put up with in the buildup to this fight, and the American needs no further motivation to shut his opponent, his entourage, and the entire boxing industry up. 

Sweethands' 59% knockout ratio doesn't compare favourably with the 88% of Benavidez, but his knockout-of-the-year takedown of Anthony Dirrell in October shows that Plant still has plenty of ammunition in his armory. 

The Benavidez vs Caleb Plant main card is due to start at 9pm ET on Saturday, 25th March, in Las Vegas, USA. That's 2am BST / 12pm AEDT on Sunday, 26th March. Below, we've curated all the info for boxing fans looking for a Benavidez vs Caleb Plant live stream in the UK, Canada, US, Australia and beyond.... -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
