### PR TITLE
fix: use jsonClone to fix cache layer

### DIFF
--- a/lib/read-json.js
+++ b/lib/read-json.js
@@ -67,12 +67,12 @@ function jsonClone (obj) {
   } else if (Array.isArray(obj)) {
     var newarr = new Array(obj.length)
     for (var ii in obj) {
-      newarr[ii] = obj[ii]
+      newarr[ii] = jsonClone(obj[ii])
     }
   } else if (typeof obj === 'object') {
     var newobj = {}
     for (var kk in obj) {
-      newobj[kk] = jsonClone[kk]
+      newobj[kk] = jsonClone(obj[kk])
     }
   } else {
     return obj
@@ -505,7 +505,7 @@ function final (file, data, log, strict, cb) {
 }
 
 function fillTypes (file, data, cb) {
-  var index = data.main ? data.main : 'index.js'
+  var index = data.main || 'index.js'
 
   if (typeof index !== 'string') {
     return cb(new TypeError('The "main" attribute must be of type string.'))

--- a/lib/read-json.js
+++ b/lib/read-json.js
@@ -69,11 +69,13 @@ function jsonClone (obj) {
     for (var ii in obj) {
       newarr[ii] = jsonClone(obj[ii])
     }
+    return newarr
   } else if (typeof obj === 'object') {
     var newobj = {}
     for (var kk in obj) {
       newobj[kk] = jsonClone(obj[kk])
     }
+    return newobj
   } else {
     return obj
   }
@@ -115,7 +117,6 @@ function parseJson (file, er, d, log, strict, cb) {
       return cb(parseError(jsonErr, file))
     }
   }
-
   extrasCached(file, d, data, log, strict, cb)
 }
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,53 @@
+var path = require('path')
+
+var tap = require('tap')
+
+var readJson = require('../')
+var file = path.resolve(__dirname, 'fixtures/deepnested.json')
+
+tap.test('cache test', function (t) {
+  var count = 0
+  var spy = function (file_, data_, then) {
+    count++
+    then()
+  }
+
+  readJson.extraSet.push(spy)
+  t.teardown(function () {
+    readJson.extraSet.pop()
+  })
+
+  readJson(file, function (er, data) {
+    if (er) {
+      throw er
+    }
+    var expectedProp = [
+      {
+        prop: {
+          prop: [
+            {
+              prop: 'prop',
+            },
+          ],
+        },
+      },
+    ]
+    t.ok(data)
+    t.equal(data.name, 'deep-nested')
+    t.equal(data.version, '1.2.3')
+    t.equal(data._id, data.name + '@' + data.version)
+    t.same(data.prop, expectedProp)
+
+    data.prop = null
+
+    readJson(file, function (er2, data2) {
+      if (er2) {
+        throw er2
+      }
+      t.same(data2.prop, expectedProp)
+      t.not(data2.prop, data.prop)
+      t.equal(count, 1)
+      t.end()
+    })
+  })
+})

--- a/test/fixtures/deepnested.json
+++ b/test/fixtures/deepnested.json
@@ -1,0 +1,15 @@
+{
+  "name": "deep-nested",
+  "version": "1.2.3",
+  "prop": [
+    {
+      "prop": {
+        "prop": [
+          {
+            "prop": "prop"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What / Why
Some objects may get corrupted during caching
**UPD** Finally figured out that the cache does not work at all

## Actual impl
https://github.com/npm/read-package-json/commit/52ad4c5dc1b526fb6302b36f28d4d977f668d2c5
```js
newobj[kk] = jsonClone[kk] // refers to `jsonClone` helper field instead of the origin obj
```

## Expected
```js
newobj[kk] = jsonClone(obj[kk])
```
