### PR TITLE
chore: fix tests for node v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
   },
   "tap": {
-    "branches": 68,
-    "functions": 74,
-    "lines": 74,
-    "statements": 74,
+    "branches": 73,
+    "functions": 77,
+    "lines": 77,
+    "statements": 77,
     "nyc-arg": [
       "--exclude",
       "tap-snapshots/**"

--- a/test/helpful.js
+++ b/test/helpful.js
@@ -6,7 +6,7 @@ var p = path.resolve(__dirname, 'fixtures/erroneous.json')
 tap.test('erroneous package data', function (t) {
   readJson(p, function (er, data) {
     t.ok(er instanceof Error)
-    t.ok(er.message.match(/Unexpected token "'" \(0x27\)/))
+    t.equal(er.code, 'EJSONPARSE')
     t.end()
   })
 })


### PR DESCRIPTION
node v20 gives a totally different error message parsing the invalid JSON
