### PR TITLE
fix: prevent directory.bin referencing outside the package root

### DIFF
--- a/lib/read-json.js
+++ b/lib/read-json.js
@@ -352,7 +352,7 @@ function bins (file, data, cb) {
     return cb(null, data)
   }
 
-  m = path.resolve(path.dirname(file), m)
+  m = path.resolve(path.dirname(file), path.join('.', path.join('/', m)))
   glob('**', { cwd: m })
     .then(binsGlob => bins_(file, data, binsGlob, cb))
     .catch(er => cb(er))

--- a/lib/read-json.js
+++ b/lib/read-json.js
@@ -348,7 +348,7 @@ function bins (file, data, cb) {
   data = normalizePackageBin(data)
 
   var m = data.directories && data.directories.bin
-  if (data.bin || !m) {
+  if (data.bin || !m || typeof m !== 'string') {
     return cb(null, data)
   }
 

--- a/lib/read-json.js
+++ b/lib/read-json.js
@@ -348,7 +348,7 @@ function bins (file, data, cb) {
   data = normalizePackageBin(data)
 
   var m = data.directories && data.directories.bin
-  if (data.bin || !m || typeof m !== 'string') {
+  if (data.bin || !m) {
     return cb(null, data)
   }
 

--- a/test/bin.js
+++ b/test/bin.js
@@ -41,3 +41,25 @@ tap.test('Empty bin test', function (t) {
     t.end()
   })
 })
+
+tap.test('Bin dir test', function (t) {
+  var p = path.resolve(__dirname, 'fixtures/bindir.json')
+  var warn = createWarningCollector()
+  readJson(p, warn, function (er, data) {
+    t.equal(warn.warnings.length, 0)
+    t.equal(data.name, 'bindir-test')
+    t.strictSame(data.bin, { echo: 'bin/echo' })
+    t.end()
+  })
+})
+
+tap.test('Bin dir trim prefix test', function (t) {
+  var p = path.resolve(__dirname, 'fixtures/bindiroutofscope.json')
+  var warn = createWarningCollector()
+  readJson(p, warn, function (er, data) {
+    t.equal(warn.warnings.length, 0)
+    t.equal(data.name, 'bindiroutofscope-test')
+    t.strictSame(data.bin, { echo: 'bin/echo' })
+    t.end()
+  })
+})

--- a/test/fixtures/bindir.json
+++ b/test/fixtures/bindir.json
@@ -1,0 +1,14 @@
+{
+  "name": "bindir-test",
+  "description": "my desc",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/npm/read-package-json.git"
+  },
+  "version": "0.0.1",
+  "readme": "hello world",
+  "directories": {
+    "bin": "./bin"
+  },
+  "license": "ISC"
+}

--- a/test/fixtures/bindiroutofscope.json
+++ b/test/fixtures/bindiroutofscope.json
@@ -1,0 +1,14 @@
+{
+  "name": "bindiroutofscope-test",
+  "description": "my desc",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/npm/read-package-json.git"
+  },
+  "version": "0.0.1",
+  "readme": "hello world",
+  "directories": {
+    "bin": "../../../../../bin"
+  },
+  "license": "ISC"
+}


### PR DESCRIPTION
## What / Why 
Avoid `directory.bin` referencing outside the package root

## References
Continues https://github.com/npm/npm-normalize-package-bin/pull/41
