### PR TITLE
fix: Update glob to support Node 20 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "template-oss-apply": "template-oss-apply --force"
   },
   "dependencies": {
-    "glob": "^10.2.2",
+    "glob": "^10.3.10",
     "json-parse-even-better-errors": "^3.0.0",
     "normalize-package-data": "^6.0.0",
     "npm-normalize-package-bin": "^3.0.0"


### PR DESCRIPTION
The version of glob used in the project currently is having path-scurry 1.7.0 as a dependency, but that version of path-scurry has conflict with
  `@types/node` version 20.x.

This PR bumps glob to version 10.3.10 which has an updated version `path-scurry@1.10.1`, and allows using the latest node types with TypeScript.

Related to https://github.com/isaacs/node-glob/issues/537