### PR TITLE
fix: update `npm help` statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Reads the JSON file and does the things.
 
 ## `package.json` Fields
 
-See `man 5 package.json` or `npm help json`.
+See `man 5 package.json` or `npm help package-json`.
 
 ## readJson.log
 


### PR DESCRIPTION
`npm help json` leads to 404. The correct statement is `npm help package-json`, which will display

`npm\docs\output\configuring-npm\package-json.html`